### PR TITLE
Restrict Unitful compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,5 +12,5 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 Quaternions = "0.4"
 StaticArrays = "0.12, 1.0"
-Unitful = "1"
+Unitful = "1.12.3"
 julia = "1.4"


### PR DESCRIPTION
Unitful versions older than v1.12.3 assume that multiplication is commutative, which is wrong for quaternions (see https://github.com/PainterQubits/Unitful.jl/issues/607, https://github.com/PainterQubits/Unitful.jl/pull/608).

This restricts the version of Unitful that is used with this package to v1.12.3 or newer.